### PR TITLE
Fix Issue #42: DataLoader workers crash

### DIFF
--- a/dataset.py
+++ b/dataset.py
@@ -11,20 +11,35 @@ class LMDBLatentsDataset(torch.utils.data.Dataset):
         flip_prob (float): flip or upflip.
     """
     def __init__(self, lmdb_path, flip_prob=0.5):
-        self.env = lmdb.open(lmdb_path,
+        self.lmdb_path = lmdb_path
+        self.flip_prob = flip_prob
+        self.env = None  # Will be lazily initialized per-worker
+        
+        # Read length using a temporary connection (closed immediately)
+        tmp_env = lmdb.open(lmdb_path,
                            readonly=True,
                            lock=False,
                            readahead=False,
                            meminit=False)
-        
-        with self.env.begin() as txn:
+        with tmp_env.begin() as txn:
             self.length = int(txn.get('num_samples'.encode()).decode())
-        self.flip_prob = flip_prob
+        tmp_env.close()
+    
+    def _init_env(self):
+        """Lazily initialize LMDB environment (called once per worker process)."""
+        if self.env is None:
+            self.env = lmdb.open(self.lmdb_path,
+                                readonly=True,
+                                lock=False,
+                                readahead=False,
+                                meminit=False)
     
     def __len__(self):
         return self.length
     
     def __getitem__(self, index):
+        self._init_env()  # Ensure env is initialized in this worker
+        
         with self.env.begin() as txn:
             data = txn.get(f'{index}'.encode())
             if data is None:
@@ -44,5 +59,9 @@ class LMDBLatentsDataset(torch.utils.data.Dataset):
             return moments_tensor, label
     
     def __del__(self):
-        self.env.close()
+        if hasattr(self, 'env') and self.env is not None:
+            try:
+                self.env.close()
+            except Exception:
+                pass
 


### PR DESCRIPTION
## Fix LMDB fork-safety and distributed initialization in main_cache.py

Hey, not sure if its helpful, but I solved the issue #42  where data conversion is failing with segfault.

### Problem

Two issues causing crashes during preprocessing:

1. **Segmentation faults with `num_workers > 0`**: LMDB environments are not fork-safe. Opening the LMDB connection in `__init__` causes crashes when DataLoader forks worker processes.

2. **Crash at 99% completion**: `dist.barrier()` is called without initializing the distributed process group.

### Solution

1. **Lazy LMDB initialization**: Store the path in `__init__` and defer opening the LMDB environment until first access in `__getitem__`. Each worker process opens its own connection.

2. **Proper distributed setup**: Add `dist.init_process_group(backend="nccl")` at start and `dist.destroy_process_group()` in cleanup.

### Changes

- `LMDBImageNetReader`: Use lazy initialization pattern for LMDB environment
- `preprocess_latents()`: Add `dist.init_process_group()` and cleanup
- `dataset.py`: Apply same lazy init fix to `LMDBLatentsDataset` (prevents same issue during training)

### Testing

Successfully completed preprocessing of ImageNet with 8 GPUs and `num_workers=2` on my Ubuntu machine.